### PR TITLE
Update rules_python dependency versions

### DIFF
--- a/python/pip_install/parse_requirements_to_bzl/extract_single_wheel/__init__.py
+++ b/python/pip_install/parse_requirements_to_bzl/extract_single_wheel/__init__.py
@@ -21,12 +21,29 @@ def main() -> None:
         required=True,
         help="A single PEP508 requirement specifier string.",
     )
+    parser.add_argument(
+        "--pip_platform_definition",
+        help="A pip platform definition in the form <platform>-<python_version>-<implementation>-<abi>",
+    )
     arguments.parse_common_args(parser)
     args = parser.parse_args()
 
     configure_reproducible_wheels()
 
-    pip_args = [sys.executable, "-m", "pip", "--isolated", "wheel", "--no-deps"]
+    pip_args = [sys.executable, "-m", "pip", "--isolated"]
+    if args.pip_platform_definition:
+        platform, python_version, implementation, abi = args.pip_platform_definition.split("-")
+        pip_args.extend([
+            "download",
+            "--only-binary", ":all:",
+            "--platform", platform,
+            "--python-version", python_version,
+            "--implementation", implementation,
+            "--abi", abi
+        ])
+    else:
+        pip_args.append("wheel")
+    pip_args.append("--no-deps")
     if args.extra_pip_args:
         pip_args += json.loads(args.extra_pip_args)["args"]
 

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -46,7 +46,6 @@ def _parse_optional_attrs(rctx, args):
 
     if rctx.attr.enable_implicit_namespace_pkgs:
         args.append("--enable_implicit_namespace_pkgs")
-
     return args
 
 _BUILD_FILE_CONTENTS = """\
@@ -88,6 +87,11 @@ def _pip_repository_impl(rctx):
             "--timeout",
             str(rctx.attr.timeout),
         ]
+        if rctx.attr.pip_platform_definitions:
+            args.extend([
+                "--pip_platform_definitions",
+                struct(args = {str(k): v for k, v in rctx.attr.pip_platform_definitions.items()}).to_json(),
+            ])
     else:
         args = [
             python_interpreter,
@@ -170,6 +174,11 @@ of 'requirements' no resolve will take place and pip_repository will create indi
 wheels are fetched/built only for the targets specified by 'build/run/test'.
 """,
     ),
+    "pip_platform_definitions": attr.label_keyed_string_dict(
+        doc = """
+A map of select keys to platform definitions in the form <platform>-<python_version>-<implementation>-<abi>"
+        """
+    )
 }
 
 pip_repository_attrs.update(**common_attrs)
@@ -232,6 +241,11 @@ def _impl_whl_library(rctx):
         rctx.attr.repo,
     ]
     args = _parse_optional_attrs(rctx, args)
+    if rctx.attr.pip_platform_definition:
+        args.extend([
+            "--pip_platform_definition",
+            rctx.attr.pip_platform_definition,
+        ])
     result = rctx.execute(
         args,
         environment = {
@@ -256,6 +270,9 @@ whl_library_attrs = {
         mandatory = True,
         doc = "Python requirement string describing the package to make available",
     ),
+    "pip_platform_definition": attr.string(
+        doc = "A pip platform definition in the form <platform>-<python_version>-<implementation>-<abi>",
+    )
 }
 
 whl_library_attrs.update(**common_attrs)
@@ -266,4 +283,30 @@ whl_library = repository_rule(
 Download and extracts a single wheel based into a bazel repo based on the requirement string passed in.
 Instantiated from pip_repository and inherits config options from there.""",
     implementation = _impl_whl_library,
+)
+
+_PLATFORM_ALIAS_TMPL = """
+alias(
+    name = "pkg",
+    actual = select({select_items}),
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _impl_platform_alias(rctx):
+    rctx.file(
+        "BUILD",
+        content = _PLATFORM_ALIAS_TMPL.format(
+            select_items = rctx.attr.select_items
+        ),
+        executable = False,
+    )
+
+platform_alias = repository_rule(
+    attrs = {
+        "select_items": attr.string_dict()
+    },
+    implementation = _impl_platform_alias,
+    doc = """
+An internal rule used to create an alias for a pip package for the appropriate platform."""
 )

--- a/python/pip_install/pip_repository.bzl
+++ b/python/pip_install/pip_repository.bzl
@@ -32,10 +32,13 @@ def _parse_optional_attrs(rctx, args):
         args: A list of parsed args for the rule.
     Returns: Augmented args list.
     """
-    if rctx.attr.extra_pip_args:
+    extra_args = list(rctx.attr.extra_pip_args)
+    for target in rctx.attr.extra_index_url_targets:
+        extra_args += ["--extra-index-url", "file://" + str(rctx.path(target)).split("/index.html")[0]]
+    if extra_args:
         args += [
             "--extra_pip_args",
-            struct(args = rctx.attr.extra_pip_args).to_json(),
+            struct(args = extra_args).to_json(),
         ]
 
     if rctx.attr.pip_data_exclude:
@@ -151,6 +154,10 @@ python_interpreter.
         default = 600,
         doc = "Timeout (in seconds) on the rule's execution duration.",
     ),
+    "extra_index_url_targets": attr.label_list(
+        default = [],
+        doc = "Bazel labels for directories which should be passed to pip's --extra-index-url flag",
+    )
 }
 
 pip_repository_attrs = {

--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -6,33 +6,33 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 _RULE_DEPS = [
     (
         "pypi__click",
-        "https://files.pythonhosted.org/packages/d2/3d/fa76db83bf75c4f8d338c2fd15c8d33fdd7ad23a9b5e57eb6c5de26b430e/click-7.1.2-py2.py3-none-any.whl",
-        "dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc",
+        "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl",
+        "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
     ),
     (
         "pypi__pip",
-        "https://files.pythonhosted.org/packages/fe/ef/60d7ba03b5c442309ef42e7d69959f73aacccd0d86008362a681c4698e83/pip-21.0.1-py3-none-any.whl",
-        "37fd50e056e2aed635dec96594606f0286640489b0db0ce7607f7e51890372d5",
+        "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl",
+        "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
     ),
     (
         "pypi__pip_tools",
-        "https://files.pythonhosted.org/packages/6d/16/75d65bdccd48bb59a08e2bf167b01d8532f65604270d0a292f0f16b7b022/pip_tools-5.5.0-py2.py3-none-any.whl",
-        "10841c1e56c234d610d0466447685b9ea4ee4a2c274f858c0ef3c33d9bd0d985",
+        "https://files.pythonhosted.org/packages/0d/dc/38f4ce065e92c66f058ea7a368a9c5de4e702272b479c0992059f7693941/pip_tools-7.4.1-py3-none-any.whl",
+        "4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9",
     ),
     (
         "pypi__pkginfo",
-        "https://files.pythonhosted.org/packages/4f/3c/535287349af1b117e082f8e77feca52fbe2fdf61ef1e6da6bcc2a72a3a79/pkginfo-1.6.1-py2.py3-none-any.whl",
-        "ce14d7296c673dc4c61c759a0b6c14bae34e34eb819c0017bb6ca5b7292c56e9",
+        "https://files.pythonhosted.org/packages/56/09/054aea9b7534a15ad38a363a2bd974c20646ab1582a387a95b8df1bfea1c/pkginfo-1.10.0-py3-none-any.whl",
+        "889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097",
     ),
     (
         "pypi__setuptools",
-        "https://files.pythonhosted.org/packages/70/06/849cc805ac6332210083f2114a95b22ee252ce81ed4e1be4f1d2b87c9108/setuptools-54.0.0-py3-none-any.whl",
-        "d85b57c41e88b69ab87065c964134ec85b7573cbab0fdaa7ef32330ed764600a",
+        "https://files.pythonhosted.org/packages/f7/29/13965af254e3373bceae8fb9a0e6ea0d0e571171b80d6646932131d6439b/setuptools-69.5.1-py3-none-any.whl",
+        "c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32",
     ),
     (
         "pypi__wheel",
-        "https://files.pythonhosted.org/packages/65/63/39d04c74222770ed1589c0eaba06c05891801219272420b40311cd60c880/wheel-0.36.2-py2.py3-none-any.whl",
-        "78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e",
+        "https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl",
+        "55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81",
     ),
 ]
 


### PR DESCRIPTION
Updating dependency versions in `python/pip_install/repositories.bzl` since the currently pinned version of `pkginfo` breaks the generated build rule for certain packages.

This commit is on top of commit `68656f58fbda9b9a30ed62dc5fdcb68f4cce2362` which is currently used for the `rules_python` http archive rule.